### PR TITLE
Adds fix for clipped route

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function v5(response) {
     // Generate segments
     response.routes[0].legs.forEach(function(leg) {
         segments = segments.concat(leg.steps.reduce(function(joined, step) {
-            if (!step.geometry) return joined;
+            if (!step.geometry || step.geometry.type !== 'LineString') return joined;
             var next = geom(step.geometry);
             joined.geometry.coordinates = joined.geometry.coordinates.concat(next.coordinates);
             return joined;


### PR DESCRIPTION
@yhahn I noticed that the v5 responses were getting clipped short. It seems that it's because the final step in v5 responses is now a `Point`, whose coordinates === the final coordinates in the penultimate feature (i.e., the last `LineString` before the destination `Point). This was causing the two coordinates to be repeated in the LineString, which I guess causes the LineString to give up ¯_(ツ)_/¯

**Before**
![broken](https://cloud.githubusercontent.com/assets/6913048/15411685/a6ce25ca-1def-11e6-9593-867237924887.gif)

**After**
![fixed](https://cloud.githubusercontent.com/assets/6913048/15411686/ac3806fc-1def-11e6-8a19-079ff589c570.gif)

Do you see any problem with categorically filtering for `LineString` geometry types in the segment construction?
