### PR TITLE
Swaps out deprecated GeoJSONSource

### DIFF
--- a/index.js
+++ b/index.js
@@ -313,7 +313,10 @@ function styleRoute(mapboxgl, map, route) {
     if (!style.metadata || !style.metadata.guidanceRoute) throw new Error('metadata.guidanceRoute not found. Did you run stylePrep() on your style object?');
     if (route.type !== 'FeatureCollection') route = guidance(route);
 
-    map.addSource('route-guidance', new mapboxgl.GeoJSONSource({ data: route }));
+    map.addSource('route-guidance', {
+      type: 'geojson',
+      data: route
+    });
 
     var toAdd = JSON.parse(JSON.stringify(style.metadata.guidanceRoute)).reverse();
     var byId = toAdd.reduce(function(memo, item) {

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -86,9 +86,6 @@ tape('styleRoute-geojson', function(assert) {
         features: []
     };
     var mapboxgl = {};
-    mapboxgl.GeoJSONSource = function(options) {
-        assert.equal(options.data.type, 'FeatureCollection', 'geojson data provided to GeoJSONSource constructor');
-    };
     var map = {};
     map.getStyle = function() {
         return {
@@ -124,7 +121,7 @@ tape('styleRoute-geojson', function(assert) {
     };
     map.addSource = function(id, source) {
         assert.equal(id, 'route-guidance', 'addSource: adds source with id=route-guidance');
-        assert.equal(source instanceof mapboxgl.GeoJSONSource, true, 'addSource: adds GeoJSONSource');
+        assert.equal(source.data.type, 'FeatureCollection', 'geojson data provided to GeoJSONSource constructor');;
     };
 
     var added = [];
@@ -196,7 +193,7 @@ tape('styleRoute-route', function(assert) {
     };
     map.addSource = function(id, source) {
         assert.equal(id, 'route-guidance', 'addSource: adds source with id=route-guidance');
-        assert.equal(source instanceof mapboxgl.GeoJSONSource, true, 'addSource: adds GeoJSONSource');
+        assert.equal(source.data.type, 'FeatureCollection', 'geojson data provided to GeoJSONSource constructor');
     };
 
     var added = [];


### PR DESCRIPTION
Refs [issue #7 ](https://github.com/mapbox/guidance-geojson/issues/7)

This PR tracks the removal of `GeoJSONSource` from the `map.addSource` function. @yhahn, mind taking a look? Tested with `guidance-sim` and route line looked 👌 
